### PR TITLE
Fix: Give generic unique quarter the FULL_TILE tag

### DIFF
--- a/detailed-map-tacks/ui/map-tack-core/dmt-map-tack-generics.js
+++ b/detailed-map-tacks/ui/map-tack-core/dmt-map-tack-generics.js
@@ -100,7 +100,7 @@ class MapTackGenericsSingleton {
             icon: `url(blp:city_uniquequarter)`,
             name: "LOC_UI_PRODUCTION_UNIQUE_QUARTER",
             classType: ConstructibleClassType.BUILDING,
-            tags: ["AGELESS"],
+            tags: ["AGELESS", "FULL_TILE"],
             adjacencyIds: []
         });
         this.genericMapTacks.set("DMT_WONDER", {


### PR DESCRIPTION
From my reading of the wiki, it looks like the unique quarter buildings do not share universally consistent adjacency bonuses. The one common thread is Wonders, but the bonuses differ depending on the building type (science, culture, even influence).

No rush, thank you again!