### PR TITLE
Update ru_RU_Text.xml

### DIFF
--- a/detailed-map-tacks/l10n/ru_RU_Text.xml
+++ b/detailed-map-tacks/l10n/ru_RU_Text.xml
@@ -2,7 +2,7 @@
 <Database>
     <LocalizedText>
         <Replace Tag="LOC_DMT_MAP_TACKS" Language="ru_RU">
-            <Text>Отметки на карте</Text>
+            <Text>Булавки</Text>
         </Replace>
         <Replace Tag="LOC_DMT_PLACEMENT_DETAILS" Language="ru_RU">
             <Text>Детали размещения</Text>


### PR DESCRIPTION
Current lens name is too long so it takes too much space in the panel (2 rows). Moreover, the new word "Булавки" is used in other strings of this mod and was used in Civ6. Please, consider the change :)