### PR TITLE
ignore unique improvements & walls in validator

### DIFF
--- a/detailed-map-tacks/ui/map-tack-chooser/dmt-map-tack-chooser.js
+++ b/detailed-map-tacks/ui/map-tack-chooser/dmt-map-tack-chooser.js
@@ -191,7 +191,7 @@ class MapTackChooser extends Panel {
         for (const itemDef of GameInfo.Constructibles) {
             if (classType == itemDef.ConstructibleClass
                     && !this.excludedConstructibles.has(itemDef.ConstructibleType)
-                    && !(itemDef.DistrictDefense && itemDef.ExistingDistrictOnly) // Filter out walls.
+                    && !itemDef.ExistingDistrictOnly // Filter out walls.
                     && !(itemDef.Age != null && itemDef.Age != this.currentAge) // Filter out items that don't belong to this age.
                     && !itemDef.Discovery) {
                 filteredItemDefs.push(itemDef);

--- a/detailed-map-tacks/ui/map-tack-core/dmt-map-tack-utils.js
+++ b/detailed-map-tacks/ui/map-tack-core/dmt-map-tack-utils.js
@@ -111,6 +111,10 @@ class MapTackUtilsSingleton {
         const tags = this.constructibleTypeTags[constructibleType];
         return tags && tags.includes(tag);
     }
+    isSlotless(type) {
+        // Walls, for example.
+        return this.hasTag(type, "IGNORE_DISTRICT_PLACEMENT_CAP");
+    }
     isFullTile(type) {
         // Full tile buildings check.
         if (this.hasTag(type, "FULL_TILE")) {
@@ -138,7 +142,7 @@ class MapTackUtilsSingleton {
         if (classType == ConstructibleClassType.WONDER) {
             return false;
         } else if (classType == ConstructibleClassType.IMPROVEMENT) {
-            return this.isCommonImprovement(type);
+            return true;
         } else {
             return !this.isAgeless(type) && this.isObsolete(type);
         }

--- a/detailed-map-tacks/ui/map-tack-core/dmt-map-tack-validator.js
+++ b/detailed-map-tacks/ui/map-tack-core/dmt-map-tack-validator.js
@@ -104,7 +104,8 @@ class MapTackValidatorSingleton {
         const classType = MapTackUtils.getConstructibleClassType(type);
 
         // START - Number of constructibles check.
-        const existingConstructibles = plotDetails["constructibles"].filter(c => !MapTackUtils.canBeBuiltOver(c));
+        const existingConstructibles = plotDetails["constructibles"]
+            .filter(c => !MapTackUtils.canBeBuiltOver(c) && !MapTackUtils.isSlotless(c));
         const uniqueTypesUnderCheck = new Set([type, ...newMapTacks, ...existingConstructibles]);
         // 1. Max number of map tacks per plot check.
         if (uniqueTypesUnderCheck.size > MAX_COUNT_PER_PLOT) {


### PR DESCRIPTION
the validator is incorrectly marking some hexes as invalid because they contain unique improvements or walls.  all UIs are overbuildable, and walls do not take up a building slot, so neither one should interfere with building or tack placement.

i also simplified the current check for walls to just `itemDef.ExistingDistrictOnly` because that's how vanilla civ checks for them in the building placement layer.  i used a stricter definition in the new `isSlotless()` method based on the `IGNORE_DISTRICT_PLACEMENT_CAP` tag. perhaps both checks should use the same test instead?