### PR TITLE
configurable map tack layer

### DIFF
--- a/detailed-map-tacks/ui/lenses/layer/dmt-map-tack-layer.js
+++ b/detailed-map-tacks/ui/lenses/layer/dmt-map-tack-layer.js
@@ -1,6 +1,9 @@
 import MapTackUtils from '../../map-tack-core/dmt-map-tack-utils.js';
 import { L as LensManager, a as LensActivationEventName } from '/core/ui/lenses/lens-manager.chunk.js';
 import { BuildingPlacementManager } from '/base-standard/ui/building-placement/building-placement-manager.js';
+// guarantee import order for patching
+import '/base-standard/ui/lenses/lens/default-lens.js';
+import '/base-standard/ui/lenses/lens/settler-lens.js';
 
 class MapTackLensLayer {
     constructor() {
@@ -53,9 +56,16 @@ class MapTackLensLayer {
     getKey(x, y) {
         return `${x}-${y}`;
     }
+    getOptionName() {
+        return "dmtShowMapTacks";
+    }
 }
-LensManager.registerLensLayer("dmt-map-tack-layer", new MapTackLensLayer());
-// Enable map tack layer in default lens.
+// Enable map tack layer in default lens (configurable).
 const defaultLens = LensManager.lenses.get("fxs-default-lens");
 defaultLens.allowedLayers.add("dmt-map-tack-layer");
-defaultLens.activeLayers.add("dmt-map-tack-layer");
+// if layer is not configured, enable it by default
+const instance = new MapTackLensLayer();
+const option = UI.getOption("user", "Gameplay", instance.getOptionName());
+if (option == null) UI.setOption("user", "Gameplay", instance.getOptionName(), 1);
+// register layer
+LensManager.registerLensLayer("dmt-map-tack-layer", instance);

--- a/detailed-map-tacks/ui/lenses/layer/dmt-map-tack-layer.js
+++ b/detailed-map-tacks/ui/lenses/layer/dmt-map-tack-layer.js
@@ -9,16 +9,17 @@ class MapTackLensLayer {
     constructor() {
     }
     initLayer() {
+        document.body.classList.add("dmt-layer-hidden");
         window.addEventListener('layer-hotkey', this.onLayerHotkey.bind(this));
         window.addEventListener(LensActivationEventName, this.onActiveLensChanged.bind(this));
 
         this.mapTackModelGroup = WorldUI.createModelGroup("MapTackModelGroup");
     }
     applyLayer() {
-        window.dispatchEvent(new Event("ui-show-map-tack-icons"));
+        document.body.classList.remove("dmt-layer-hidden");
     }
     removeLayer() {
-        window.dispatchEvent(new Event("ui-hide-map-tack-icons"));
+        document.body.classList.add("dmt-layer-hidden");
     }
     onLayerHotkey(hotkey) {
         if (hotkey.detail?.name == "toggle-map-tack-layer") {

--- a/detailed-map-tacks/ui/plot-icons/dmt-map-tack-icons.css
+++ b/detailed-map-tacks/ui/plot-icons/dmt-map-tack-icons.css
@@ -1,7 +1,11 @@
 dmt-map-tack-icons {
-	pointer-events: none;
-	position: absolute;
+    pointer-events: none;
+    position: absolute;
     z-index: 1;
+}
+
+.dmt-layer-hidden dmt-map-tack-icons {
+    display: none;
 }
 
 .map-tack-icon-container {

--- a/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
+++ b/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
@@ -10,9 +10,6 @@ class DMT_PlotIconsRootDecorator {
         this.component = component;
         this.componentRoot = component.Root;
         this.updateMapTackListener = this.onUpdateMapTack.bind(this);
-        this.globalHidden = false;
-        this.globalHideListener = this.onGlobalHide.bind(this);
-        this.globalShowListener = this.onGlobalShow.bind(this);
     }
 
     beforeAttach() {
@@ -20,15 +17,11 @@ class DMT_PlotIconsRootDecorator {
 
     afterAttach() {
         this.componentRoot.addEventListener(MapTackIconRootUpdateEventName, this.updateMapTackListener);
-        window.addEventListener("ui-hide-map-tack-icons", this.globalHideListener);
-        window.addEventListener("ui-show-map-tack-icons", this.globalShowListener);
         MapTackIconsManager.rootAttached(this.componentRoot);
     }
 
     beforeDetach() {
         this.componentRoot.removeEventListener(MapTackIconRootUpdateEventName, this.updateMapTackListener);
-        window.removeEventListener("ui-hide-map-tack-icons", this.globalHideListener);
-        window.removeEventListener("ui-show-map-tack-icons", this.globalShowListener);
     }
 
     afterDetach() {
@@ -65,20 +58,6 @@ class DMT_PlotIconsRootDecorator {
                 this.removeIcon(mapTackStruct);
             }
         }
-    }
-    onGlobalHide() {
-        const mapTackIconRoots = this.componentRoot.querySelectorAll(MAP_TACK_ELEMENT_NAME);
-        mapTackIconRoots.forEach((mapTackIconRoot) => {
-            mapTackIconRoot.style.display = 'none';
-        });
-        this.globalHidden = true;
-    }
-    onGlobalShow() {
-        const mapTackIconRoots = this.componentRoot.querySelectorAll(MAP_TACK_ELEMENT_NAME);
-        mapTackIconRoots.forEach((mapTackIconRoot) => {
-            mapTackIconRoot.style.display = '';
-        });
-        this.globalHidden = false;
     }
 }
 Controls.decorate('plot-icons-root', (component) => new DMT_PlotIconsRootDecorator(component));

--- a/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
+++ b/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
@@ -1,7 +1,6 @@
 
 import MapTackIconsManager, { MapTackIconRootUpdateEventName } from './dmt-map-tack-icons-manager.js';
 import { MAP_TACK_ELEMENT_NAME } from './dmt-map-tack-icons.js';
-import { L as LensManager } from '/core/ui/lenses/lens-manager.chunk.js';
 
 // Reuse plot-icons-root since it's already attached to the root-game.html.
 class DMT_PlotIconsRootDecorator {

--- a/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
+++ b/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
@@ -27,7 +27,7 @@ class DMT_PlotIconsRootDecorator {
     afterDetach() {
     }
     // Create the MapTack icon on the desired root
-    updateIcon(mapTackStruct, isLayerEnabled) {
+    updateIcon(mapTackStruct) {
         const mapTackIcon = MapTackIconsManager.getMapTackIcon(mapTackStruct.x, mapTackStruct.y);
         let mapTackIconRoot = mapTackIcon?.Root;
         if (mapTackIconRoot == undefined) {
@@ -47,11 +47,10 @@ class DMT_PlotIconsRootDecorator {
     }
     onUpdateMapTack(event) {
         const mapTackStructList = event.detail.mapTackStructList;
-        const isLayerEnabled = LensManager.isLayerEnabled("dmt-map-tack-layer");
         for (const mapTackStruct of mapTackStructList) {
             if (mapTackStruct.mapTackList && mapTackStruct.mapTackList.length > 0) {
                 // Have map tacks on this plot, update.
-                this.updateIcon(mapTackStruct, isLayerEnabled);
+                this.updateIcon(mapTackStruct);
             } else {
                 // No map tack on this plot, remove.
                 this.removeIcon(mapTackStruct);

--- a/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
+++ b/detailed-map-tacks/ui/plot-icons/dmt-plot-icons-root-decorator.js
@@ -37,7 +37,6 @@ class DMT_PlotIconsRootDecorator {
             this.componentRoot.appendChild(mapTackIconRoot);
         }
         mapTackIconRoot.setAttribute('map-tack-list', JSON.stringify(mapTackStruct.mapTackList));
-        mapTackIconRoot.style.display = !isLayerEnabled ? 'none' : '';
     }
     removeIcon(mapTackStruct) {
         const mapTackIcon = MapTackIconsManager.getMapTackIcon(mapTackStruct.x, mapTackStruct.y);


### PR DESCRIPTION
this adds support for the game's new lens configuration system, introduced in Update 1.2.5.
to use the new feature:

- toggle a Decorations layer with the checkbox (**not** the hotkey)
- save your game

as soon as you toggle the checkbox, the setting will persist across UI reloads, age transitions, and New Game. the setting does **not** persist across game exit & restart, but loading the saved game will restore it. thus, the settings will only reset if you start a New Game immediately after startup.

implementation is simple: the LensManager handles all of the details, it just needs the new `getOptionName` method to get a unique ID for your layer configuration. the only other requirement is to add the layer to the default lens `allowedLayers` set (**not** `activeLayers`).

i also fixed a problem with the layer initialization. (the vanilla Hex Grid layer has the same problem btw.) the `initLayer` method should produce a **hidden** layer. i fixed that and also greatly simplified the hidden tack code. instead of adjusting every individual tack, i set a class on `document.body` that causes all tacks to be hidden simultaneously.