### PR TITLE
enable hotkeys during unit selection

### DIFF
--- a/detailed-map-tacks/config/Input.xml
+++ b/detailed-map-tacks/config/Input.xml
@@ -2,12 +2,14 @@
 <Database>
     <InputActions>
         <Row ActionId="open-map-tack-panel" DeviceType="Keyboard" Name="LOC_DMT_OPEN_MAP_TACK_PANEL" Description="LOC_DMT_OPEN_MAP_TACK_PANEL"/>
-    	<Row ActionId="toggle-map-tack-layer" DeviceType="Keyboard" Name="LOC_DMT_TOGGLE_MAP_TACKS" Description="LOC_DMT_TOGGLE_MAP_TACKS"/>
+        <Row ActionId="toggle-map-tack-layer" DeviceType="Keyboard" Name="LOC_DMT_TOGGLE_MAP_TACKS" Description="LOC_DMT_TOGGLE_MAP_TACKS"/>
     </InputActions>
-	<InputContextConstraints>
+    <InputContextConstraints>
+        <Row ActionId="open-map-tack-panel" ContextId="Unit"/>
         <Row ActionId="open-map-tack-panel" ContextId="World"/>
+        <Row ActionId="toggle-map-tack-layer" ContextId="Unit"/>
         <Row ActionId="toggle-map-tack-layer" ContextId="World"/>
-	</InputContextConstraints>
+    </InputContextConstraints>
     <InputActionDefaultGestures>
         <Row ActionId="open-map-tack-panel" Index="0" GestureType="KBMouse" GestureData="KEY_F2" />
         <Row ActionId="toggle-map-tack-layer" Index="0" GestureType="KBMouse" GestureData="KEY_X" />


### PR DESCRIPTION
enables map tack hotkeys while units are selected, so that users can show or hide the tacks while moving units. works the same as the vanilla hotkeys for Hex Grid, Resources, and Yields.

note: to enable the change you also need to reset your keyboard controls in the Options menu. for some reason, the game saves this setting along with edited key bindings, and the only way to update is to reset all bindings.